### PR TITLE
Add functionality to map/convert Node<Msg> to Node<SomeOtherMsg>.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ members = [
 ]
 
 [replace]
+"sauron:0.4.0" = { path = "." }
 "sauron_vdom:0.4.0" = { path = "crates/sauron_vdom" }
 
 

--- a/crates/sauron_vdom/examples/simple.rs
+++ b/crates/sauron_vdom/examples/simple.rs
@@ -1,11 +1,10 @@
+#![deny(warnings)]
 use sauron_vdom::builder::*;
 use sauron_vdom::diff;
-use sauron_vdom::Callback;
-use sauron_vdom::Event;
 use sauron_vdom::Node;
 
 fn main() {
-    let old: Node<&'static str, Callback<Event, ()>> = element(
+    let old: Node<&'static str, ()> = element(
         "div",
         [
             attr("class", "some-class"),

--- a/crates/sauron_vdom/src/patch.rs
+++ b/crates/sauron_vdom/src/patch.rs
@@ -1,6 +1,8 @@
 //! Our Patch enum is intentionally kept in it's own file for easy inclusion into
 //! The Percy Book.
 
+use crate::Callback;
+use crate::Event;
 use crate::Value;
 use crate::{Node, Text};
 use std::collections::BTreeMap;
@@ -39,20 +41,20 @@ use std::collections::BTreeMap;
 ///
 /// The patching process is tested in a real browser in tests/diff_patch.rs
 #[derive(Debug, PartialEq)]
-pub enum Patch<'a, T, CB> {
+pub enum Patch<'a, T, MSG> {
     /// Append a vector of child nodes to a parent node id.
-    AppendChildren(NodeIdx, Vec<&'a Node<T, CB>>),
+    AppendChildren(NodeIdx, Vec<&'a Node<T, MSG>>),
     /// For a `node_i32`, remove all children besides the first `len`
     TruncateChildren(NodeIdx, usize),
     /// Replace a node with another node. This typically happens when a node's tag changes.
     /// ex: <div> becomes <span>
-    Replace(NodeIdx, &'a Node<T, CB>),
+    Replace(NodeIdx, &'a Node<T, MSG>),
     /// Add attributes that the new node has that the old node does not
     AddAttributes(NodeIdx, BTreeMap<&'a str, &'a Value>),
     /// Remove attributes that the old node had that the new node doesn't
     RemoveAttributes(NodeIdx, Vec<&'a str>),
     /// Add attributes that the new node has that the old node does not
-    AddEventListener(NodeIdx, BTreeMap<&'a str, &'a CB>),
+    AddEventListener(NodeIdx, BTreeMap<&'a str, &'a Callback<Event, MSG>>),
     /// Remove attributes that the old node had that the new node doesn't
     RemoveEventListener(NodeIdx, Vec<&'a str>),
     /// Change the text of a Text node.
@@ -61,7 +63,7 @@ pub enum Patch<'a, T, CB> {
 
 type NodeIdx = usize;
 
-impl<'a, T, CB> Patch<'a, T, CB> {
+impl<'a, T, MSG> Patch<'a, T, MSG> {
     /// Every Patch is meant to be applied to a specific node within the DOM. Get the
     /// index of the DOM node that this patch should apply to. DOM nodes are indexed
     /// depth first with the root node in the tree having index 0.

--- a/crates/sauron_vdom/src/vnode.rs
+++ b/crates/sauron_vdom/src/vnode.rs
@@ -5,6 +5,7 @@ pub mod builder;
 mod event;
 mod value;
 
+use crate::Callback;
 pub use event::{Event, InputEvent, KeyEvent, MouseButton, MouseEvent};
 pub use value::Value;
 
@@ -28,17 +29,17 @@ pub use value::Value;
 /// Cloning is only done once, and happens when constructing the views into a node tree.
 /// Cloning also allows flexibility such as adding more children into an existing node/element.
 #[derive(Debug, PartialEq, Clone)]
-pub enum Node<T, CB> {
-    Element(Element<T, CB>),
+pub enum Node<T, MSG> {
+    Element(Element<T, MSG>),
     Text(Text),
 }
 
 #[derive(Debug, PartialEq, Clone, Default)]
-pub struct Element<T, CB> {
+pub struct Element<T, MSG> {
     pub tag: T,
     pub attrs: BTreeMap<String, Value>,
-    pub events: BTreeMap<String, CB>,
-    pub children: Vec<Node<T, CB>>,
+    pub events: BTreeMap<String, Callback<Event, MSG>>,
+    pub children: Vec<Node<T, MSG>>,
     pub namespace: Option<String>,
 }
 
@@ -47,7 +48,7 @@ pub struct Text {
     pub text: String,
 }
 
-impl<T, CB> Element<T, CB> {
+impl<T, MSG> Element<T, MSG> {
     /// Create a Element using the supplied tag name
     pub fn new(tag: T) -> Self {
         Element {
@@ -66,7 +67,7 @@ impl<T, CB> Element<T, CB> {
     }
 }
 
-impl<T, CB> fmt::Display for Element<T, CB>
+impl<T, MSG> fmt::Display for Element<T, MSG>
 where
     T: ToString,
 {
@@ -104,7 +105,7 @@ impl fmt::Display for Text {
 }
 
 // Turn a Node into an HTML string (delegate impl to variants)
-impl<T, CB> fmt::Display for Node<T, CB>
+impl<T, MSG> fmt::Display for Node<T, MSG>
 where
     T: ToString,
 {
@@ -116,8 +117,8 @@ where
     }
 }
 
-impl<T, CB> From<Element<T, CB>> for Node<T, CB> {
-    fn from(v: Element<T, CB>) -> Self {
+impl<T, MSG> From<Element<T, MSG>> for Node<T, MSG> {
+    fn from(v: Element<T, MSG>) -> Self {
         Node::Element(v)
     }
 }

--- a/examples/interactive/client/Cargo.toml
+++ b/examples/interactive/client/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 [dependencies]
 console_error_panic_hook = "0.1"
 js-sys = "0.3"
-sauron = { path = "../../../../sauron" }
+sauron = "0.4.0"
 lazy_static = "1.0"
 
 # `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size

--- a/examples/minimal/Cargo.toml
+++ b/examples/minimal/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-sauron = { path = "../../" }
+sauron = "0.4.0"
 wasm-bindgen = "0.2.40"
 console_error_panic_hook = { version = "0.1.1", optional = true }
 wee_alloc = { version = "0.4.3", optional = true }

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-sauron = { path = "../../" }
+sauron = "0.4.0"
 wasm-bindgen = "0.2.42"
 console_error_panic_hook = { version = "0.1.6", optional = true }
 wee_alloc = { version = "0.4.4", optional = true }

--- a/src/html/events.rs
+++ b/src/html/events.rs
@@ -1,6 +1,8 @@
 //! https://developer.mozilla.org/en-US/docs/Web/Events
 pub use sauron_vdom::builder::on;
 use sauron_vdom::builder::Attribute;
+use sauron_vdom::Callback;
+use sauron_vdom::Event;
 
 macro_rules! declare_events {
     ( $(
@@ -12,7 +14,7 @@ macro_rules! declare_events {
             $(#[$attr])*
             #[inline]
             pub fn $name<'a, F,CB>(f: F) -> Attribute<'a,CB>
-                where F: Into<CB>,
+                where F: Into<Callback<Event,CB>>,
                     CB: Clone
                 {
                     on(stringify!($event), f)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,6 @@ pub use dispatch::Dispatch;
 pub use dom::DomUpdater;
 pub use program::Program;
 pub use sauron_vdom::diff;
-use sauron_vdom::Callback;
 pub use sauron_vdom::Event;
 pub use sauron_vdom::Text;
 pub use util::{body, document, log, performance, request_animation_frame, window};
@@ -116,7 +115,7 @@ pub use util::{body, document, log, performance, request_animation_frame, window
 /// A simplified version of saurdon_vdom node, where we supplied the type for the tag
 /// which is a &'static str. The missing type is now only MSG which will be supplied by the users
 /// App code.
-pub type Node<MSG> = sauron_vdom::Node<&'static str, Callback<Event, MSG>>;
-pub type Element<MSG> = sauron_vdom::Element<&'static str, Callback<Event, MSG>>;
-pub type Patch<'a, MSG> = sauron_vdom::Patch<'a, &'static str, Callback<Event, MSG>>;
-pub type Attribute<'a, MSG> = sauron_vdom::builder::Attribute<'a, Callback<Event, MSG>>;
+pub type Node<MSG> = sauron_vdom::Node<&'static str, MSG>;
+pub type Element<MSG> = sauron_vdom::Element<&'static str, MSG>;
+pub type Patch<'a, MSG> = sauron_vdom::Patch<'a, &'static str, MSG>;
+pub type Attribute<'a, MSG> = sauron_vdom::builder::Attribute<'a, MSG>;


### PR DESCRIPTION
By letting Node operate on concrete struct `Callback<Event, MSG>`, we can call on `.map` method to convert the return value of Callback `MSG` into something else `SomeOtherMsg`.
This allows users embed view from sub components.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ivanceras/sauron/2)
<!-- Reviewable:end -->
