### PR TITLE
WIP: introduce a node! procedural macro to do html quasi quoting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 maintenance = { status = "actively-developed" }
 
 [dependencies]
+sauron-macros = { version = "0.28.2", path = "crates/sauron-macros" }
 js-sys = { version = "0.3", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 lazy_static = "1.3.0"
@@ -91,6 +92,7 @@ members = [
     "crates/sauron-md",
     "crates/sauron-syntax",
     "crates/sauron-parse",
+    "crates/sauron-macros",
     "examples/minimal",
     "examples/fetch_data",
     "examples/interactive/client",

--- a/crates/sauron-macros/Cargo.toml
+++ b/crates/sauron-macros/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "sauron-macros"
+version = "0.28.2"
+authors = ["John-John Tedro <udoprog@tedro.se>"]
+license = "MIT"
+description = "An html library for building client side webapps"
+repository = "https://github.com/ivanceras/sauron"
+documentation = "https://docs.rs/sauron"
+readme = "README.md"
+keywords = ["html", "dom", "web"]
+edition = "2018"
+
+[dependencies]
+syn = { version = "1.0.31", features = ["full"] }
+quote = {package = "quote", version = "1.0.3"}
+proc-macro2 = { version = "1.0.10" }
+
+[dev-dependencies]
+sauron = { path = "../..", version = "0.28.2" }
+
+[lib]
+proc-macro = true

--- a/crates/sauron-macros/src/lib.rs
+++ b/crates/sauron-macros/src/lib.rs
@@ -1,0 +1,168 @@
+#![recursion_limit = "256"]
+#![doc(html_root_url = "https://docs.rs/sauron/0.28.2")]
+
+use quote::ToTokens as _;
+
+extern crate proc_macro;
+
+mod node;
+
+/// Quasi-quoting macro for building sauron [Node]s.
+///
+/// The macro allows for specifying html-like elements and attributes, and
+/// supports advanced interpolation and looping.
+///
+/// [Node]: https://docs.rs/sauron/0/sauron/type.Node.html
+///
+/// # Elements
+///
+/// Both open elements with a closing tag, and elements which are immediately
+/// closed are supported:
+///
+/// ```rust
+/// use sauron::prelude::*;
+///
+/// let _: Node<()> = node!(<input type_="button" />);
+/// let _: Node<()> = node!(<h1>"A title"</h1>);
+/// ```
+///
+/// # Attributes
+///
+/// Attributes must be valid Rust identifiers. These are translated to
+/// `kebab-case` and trimmed. So `x_data_` would be translated to `x-data`.
+///
+/// Any sort of literal (like `true` or `42u32`) is supported as an attribute
+/// argument.
+///
+/// ```rust
+/// use sauron::prelude::*;
+///
+/// let _: Node<()> = node!(<input x_data_="my data" />);
+/// let _: Node<()> = node!(<input x_data_int_=42u32 x_data_bool_=true />);
+/// ```
+///
+/// Attribute values can be interpolated. These expressions must produce
+/// an attribute that can be converted into a [Value].
+///
+/// ```rust
+/// use sauron::prelude::*;
+///
+/// struct Model {
+///     value: String,
+/// }
+///
+/// impl Model {
+///     pub fn view(&self) -> Node<()> {
+///         node!(<input value={self.value.clone()} />)
+///     }
+/// }
+/// ```
+///
+/// Whole attributes can also be generated. These expressions must produce an
+/// [Attribute].
+///
+/// ```rust
+/// use sauron::prelude::*;
+///
+/// struct Model {
+///     editing: bool,
+///     completed: bool,
+/// }
+///
+/// impl Model {
+///     pub fn view(&self) -> Node<()> {
+///         node!(<input {{classes_flag([
+///             ("todo", true),
+///             ("editing", self.editing),
+///             ("completed", self.completed),
+///         ])}} />)
+///     }
+/// }
+/// ```
+///
+/// Finally, we also support empty attributes.
+///
+/// ```rust
+/// use sauron::prelude::*;
+///
+/// let _: Node<()> = node!(<button disabled />);
+/// ```
+///
+/// [Value]: https://docs.rs/sauron/0/sauron/html/attributes/enum.Value.html
+/// [Attribute]: https://docs.rs/sauron/0/sauron/type.Attribute.html
+///
+/// # Event handlers
+///
+/// Event handlers are special attributes. Any attribute that starts with `on_`
+/// will be matched with event handlers available in [sauron::dom::events].
+///
+/// ```rust
+/// use sauron::prelude::*;
+///
+/// enum Msg {
+///     Update(String),
+///     Add,
+///     Nope,
+/// }
+///
+/// struct Model {
+///     value: String,
+/// }
+///
+/// impl Model {
+///    fn view(&self) -> Node<Msg> {
+///        node! {
+///            <input
+///                class="new-todo"
+///                id="new-todo"
+///                placeholder="What needs to be done?"
+///                value={self.value.to_string()}
+///                on_input={|v: InputEvent| Msg::Update(v.value.to_string())}
+///                on_keypress={|event: KeyboardEvent| {
+///                    if event.key() == "Enter" {
+///                        Msg::Add
+///                    } else {
+///                        Msg::Nope
+///                    }
+///                }} />
+///         }
+///     }
+/// }
+/// ```
+///
+/// [sauron::dom::events]: https://docs.rs/sauron/0/sauron/dom/events/index.html
+///
+/// # Loops
+///
+/// Loops are supported through a special construct. They look and behave like
+/// regular Rust loops, except that whatever the loop body evaluates to will be
+/// appended to the child of a node.
+///
+/// The loop body must evaluate to a [Node].
+///
+/// ```rust
+/// use sauron::prelude::*;
+///
+/// struct Model {
+///     items: Vec<String>,
+/// }
+///
+/// impl Model {
+///     pub fn view(&self) -> Node<()> {
+///         node! {
+///             <ul>
+///                 {for item in &self.items {
+///                     text(item)
+///                 }}
+///             </ul>
+///         }
+///     }
+/// }
+/// ```
+///
+/// [Node]: https://docs.rs/sauron/0/sauron/type.Node.html
+#[proc_macro]
+pub fn node(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let node = syn::parse_macro_input!(input as node::Node);
+    node.to_token_stream().into()
+}

--- a/crates/sauron-macros/src/node.rs
+++ b/crates/sauron-macros/src/node.rs
@@ -1,0 +1,335 @@
+use proc_macro2::{
+    Span,
+    TokenStream,
+};
+use quote::ToTokens;
+use syn::{
+    ext::IdentExt as _,
+    parse::{
+        Parse,
+        ParseStream,
+    },
+    token,
+    Error,
+    Expr,
+    ExprForLoop,
+    Ident,
+    Lit,
+    LitStr,
+    Token,
+};
+
+pub(super) struct Node {
+    name: Ident,
+    attrs: Vec<Attribute>,
+    children: Vec<Child>,
+}
+
+impl Node {
+    /// Parse an opening node.
+    fn parse_open(
+        input: ParseStream,
+    ) -> syn::Result<(bool, Ident, Vec<Attribute>)> {
+        input.parse::<Token![<]>()?;
+        let element = input.parse::<Ident>()?;
+
+        let mut attrs = Vec::new();
+
+        while !input.is_empty() {
+            if input.peek(Token![>]) {
+                input.parse::<Token![>]>()?;
+                return Ok((true, element, attrs));
+            }
+
+            if input.peek(Token![/]) && input.peek2(Token![>]) {
+                input.parse::<Token![/]>()?;
+                input.parse::<Token![>]>()?;
+                return Ok((false, element, attrs));
+            }
+
+            attrs.push(input.parse()?);
+        }
+
+        Err(input.error(format!("Expected closing of element `{}`", element)))
+    }
+
+    fn children_to_tokens(&self, receiver: &Ident, tokens: &mut TokenStream) {
+        if !self.children.is_empty() {
+            let count = self.children.len();
+
+            tokens.extend(quote::quote! {
+                let mut #receiver = Vec::with_capacity(#count);
+            });
+
+            for c in &self.children {
+                match c {
+                    Child::Node(node) => {
+                        tokens.extend(quote::quote! {
+                            #receiver.push(#node);
+                        });
+                    }
+                    Child::LitStr(s) => {
+                        tokens.extend(quote::quote! {
+                            #receiver.push(sauron::Node::Text(String::from(#s)));
+                        });
+                    }
+                    Child::Eval(e) => {
+                        tokens.extend(quote::quote! {
+                            #receiver.push(sauron::Node::from(#e));
+                        });
+                    }
+                    Child::Loop(ExprForLoop {
+                        pat, expr, body, ..
+                    }) => {
+                        tokens.extend(quote::quote! {
+                            for #pat in #expr {
+                                #receiver.push(sauron::Node::from(#body));
+                            }
+                        });
+                    }
+                }
+            }
+        } else {
+            tokens.extend(quote::quote! {
+                let #receiver = Vec::new();
+            });
+        }
+    }
+}
+
+impl Parse for Node {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut children = Vec::new();
+
+        if !input.peek(Token![<]) {
+            return Err(input.error("expected opening caret"));
+        }
+
+        let (is_open, name, attrs) = Self::parse_open(input)?;
+
+        if is_open {
+            loop {
+                // Parse end node.
+                if input.peek(Token![<]) && input.peek2(Token![/]) {
+                    input.parse::<Token![<]>()?;
+                    input.parse::<Token![/]>()?;
+                    let end = input.parse::<Ident>()?;
+                    input.parse::<Token![>]>()?;
+
+                    if name != end {
+                        return Err(Error::new(
+                            end.span(),
+                            format!(
+                                "Closing node `{}` does not match open node `{}`",
+                                end, name
+                            ),
+                        ));
+                    }
+
+                    break;
+                }
+
+                if input.is_empty() {
+                    return Err(input.error(format!(
+                        "Expected closing of element `{}`",
+                        name
+                    )));
+                }
+
+                if input.peek(LitStr) {
+                    children.push(Child::LitStr(input.parse()?));
+                } else if input.peek(token::Brace) {
+                    let content;
+                    let _ = syn::braced!(content in input);
+
+                    let child = if content.peek(Token![for]) {
+                        let for_loop = content.parse::<ExprForLoop>()?;
+                        Child::Loop(for_loop)
+                    } else {
+                        Child::Eval(content.parse()?)
+                    };
+
+                    children.push(child);
+                } else {
+                    children.push(Child::Node(input.parse()?));
+                }
+            }
+        }
+
+        Ok(Node {
+            name,
+            attrs,
+            children,
+        })
+    }
+}
+
+impl ToTokens for Node {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let name = LitStr::new(&self.name.to_string(), self.name.span());
+        let attrs = &self.attrs;
+
+        let receiver = Ident::new("children", Span::call_site());
+        let mut children_tokens = TokenStream::new();
+        self.children_to_tokens(&receiver, &mut children_tokens);
+
+        tokens.extend(quote::quote! {{
+            let attrs = vec![#(#attrs),*];
+            #children_tokens
+            sauron::html::html_element(#name, attrs, children)
+        }});
+    }
+}
+
+enum Attribute {
+    Event {
+        name: Ident,
+        value: Expr,
+    },
+    /// A literal attribute.
+    ///
+    /// Like `<button style="border: 1px solid red;">`.
+    Lit {
+        name: LitStr,
+        value: Lit,
+    },
+    /// An expression attribute.
+    ///
+    /// The expression is expected to evaluate to a attribute `Value`.
+    ///
+    /// Like `<button style={style()}>`.
+    Expr {
+        name: LitStr,
+        value: Expr,
+    },
+    /// An empty attribute.
+    ///
+    /// Like `<button disabled>`.
+    Empty {
+        name: LitStr,
+    },
+    /// An expression expected to generate an attribute.
+    AttributeExpr {
+        value: Expr,
+    },
+}
+
+impl Attribute {
+    /// Convert a name `n` from lower_camel to kebab-case.
+    fn convert_name(n: &str) -> String {
+        let mut out = String::with_capacity(n.len());
+
+        for c in n.trim_matches('_').chars() {
+            match c {
+                '_' => out.push('-'),
+                c => out.push(c),
+            }
+        }
+
+        out
+    }
+}
+
+impl Parse for Attribute {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        if input.peek(token::Brace) {
+            let content;
+            let _ = syn::braced!(content in input);
+            let value = content.parse()?;
+            return Ok(Self::AttributeExpr { value });
+        }
+
+        let name = input.parse::<Ident>()?.unraw();
+
+        let event = match name.to_string().as_str() {
+            n if n.starts_with("on_") => true,
+            _ => false,
+        };
+
+        if event {
+            input.parse::<Token![=]>()?;
+
+            let content;
+            let _ = syn::braced!(content in input);
+
+            let value = content.parse()?;
+            Ok(Self::Event { name, value })
+        } else {
+            let name = LitStr::new(
+                &Self::convert_name(&name.to_string()),
+                name.span(),
+            );
+
+            if input.peek(Token![=]) {
+                input.parse::<Token![=]>()?;
+
+                if input.peek(token::Brace) {
+                    let content;
+                    let _ = syn::braced!(content in input);
+                    let value = content.parse()?;
+                    Ok(Self::Expr { name, value })
+                } else {
+                    let value = input.parse()?;
+                    Ok(Self::Lit { name, value })
+                }
+            } else {
+                Ok(Self::Empty { name })
+            }
+        }
+    }
+}
+
+impl ToTokens for Attribute {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            Self::Lit { name, value } => {
+                tokens.extend(quote::quote! {
+                    sauron::Attribute::new(
+                        None,
+                        #name,
+                        sauron::html::attributes::AttributeValue::Simple(
+                            sauron::html::attributes::Value::from(#value)
+                        )
+                    )
+                });
+            }
+            Self::Expr { name, value } => {
+                tokens.extend(quote::quote! {
+                    sauron::Attribute::new(
+                        None,
+                        #name,
+                        sauron::html::attributes::AttributeValue::Simple(
+                            sauron::html::attributes::Value::from(#value)
+                        )
+                    )
+                });
+            }
+            Self::Empty { name } => {
+                tokens.extend(quote::quote! {
+                    sauron::Attribute::new(
+                        None,
+                        #name,
+                        sauron::html::attributes::AttributeValue::Empty,
+                    )
+                });
+            }
+            Self::Event { name, value } => {
+                tokens.extend(quote::quote! {
+                    sauron::events::#name(#value)
+                });
+            }
+            Self::AttributeExpr { value } => {
+                tokens.extend(quote::quote! {
+                    sauron::Attribute::from(#value)
+                });
+            }
+        }
+    }
+}
+
+enum Child {
+    Node(Node),
+    LitStr(LitStr),
+    Eval(Expr),
+    Loop(ExprForLoop),
+}

--- a/examples/todomvc/src/app.rs
+++ b/examples/todomvc/src/app.rs
@@ -92,193 +92,104 @@ impl Component<Msg> for Model {
     }
 
     fn view(&self) -> Node<Msg> {
-        div(
-            vec![class("todomvc-wrapper")],
-            vec![
-                section(
-                    vec![class("todoapp")],
-                    vec![
-                        header(
-                            vec![class("header")],
-                            vec![
-                                h1(vec![], vec![text("todos")]),
-                                self.view_input(),
-                            ],
-                        ),
-                        section(
-                            vec![class("main")],
-                            vec![
-                                input(
-                                    vec![
-                                        class("toggle-all"),
-                                        r#type("checkbox"),
-                                        checked(self.is_all_completed()),
-                                        on_click(|_| Msg::ToggleAll),
-                                    ],
-                                    vec![],
-                                ),
-                                ul(vec![class("todo-list")], {
-                                    self.entries
-                                        .iter()
-                                        .filter(|e| self.filter.fit(e))
-                                        .enumerate()
-                                        .map(view_entry)
-                                        .collect::<Vec<Node<Msg>>>()
-                                }),
-                            ],
-                        ),
-                        footer(
-                            vec![class("footer")],
-                            vec![
-                                span(
-                                    vec![class("todo-count")],
-                                    vec![
-                                        strong(
-                                            vec![],
-                                            vec![text(format!(
-                                                "{}",
-                                                self.total()
-                                            ))],
-                                        ),
-                                        text(" item(s) left"),
-                                    ],
-                                ),
-                                ul(
-                                    vec![class("filters")],
-                                    vec![
-                                        self.view_filter(Filter::All),
-                                        self.view_filter(Filter::Active),
-                                        self.view_filter(Filter::Completed),
-                                    ],
-                                ),
-                                button(
-                                    vec![
-                                        class("clear-completed"),
-                                        on_click(|_| Msg::ClearCompleted),
-                                    ],
-                                    vec![text(format!(
-                                        "Clear completed ({})",
-                                        self.total_completed()
-                                    ))],
-                                ),
-                            ],
-                        ),
-                    ],
-                ),
-                footer(
-                    vec![class("info")],
-                    vec![
-                        p(vec![], vec![text("Double-click to edit a todo")]),
-                        p(
-                            vec![],
-                            vec![
-                                text("Written by "),
-                                a(
-                                    vec![
-                                        href("https://github.com/ivanceras/"),
-                                        target("_blank"),
-                                    ],
-                                    vec![text("Jovansonlee Cesar")],
-                                ),
-                            ],
-                        ),
-                        p(
-                            vec![],
-                            vec![
-                                text("Part of "),
-                                a(
-                                    vec![
-                                        href("http://todomvc.com/"),
-                                        target("_blank"),
-                                    ],
-                                    vec![text("TodoMVC")],
-                                ),
-                            ],
-                        ),
-                    ],
-                ),
-            ],
-        )
+        node! {
+            <div class="todomvc-wrapper">
+                <section class="todoapp">
+                    <header class="header">
+                        <h1>"todos"</h1>
+                        {self.view_input()}
+                    </header>
+                    <section class="main">
+                        <input
+                            class="toggle-all"
+                            r#type="checkbox"
+                            checked={self.is_all_completed()}
+                            on_click={|_| Msg::ToggleAll} />
+                        <ul class="todo-list">
+                            {for (i, e) in self.entries.iter().filter(|e| self.filter.fit(e)).enumerate() {
+                                view_entry(i, e)
+                            }}
+                        </ul>
+                    </section>
+                    <footer class="footer">
+                        <span class="todo-count">
+                            <strong>{text(format!(
+                                "{}",
+                                self.total()
+                            ))}" item(s) left"</strong>
+                        </span>
+                        <ul class="filters">
+                            {self.view_filter(Filter::All)}
+                            {self.view_filter(Filter::Active)}
+                            {self.view_filter(Filter::Completed)}
+                        </ul>
+                        <button class="clear-completed" on_click={|_| Msg::ClearCompleted}>
+                            {text(format!(
+                                "Clear completed ({})",
+                                self.total_completed()
+                            ))}
+                        </button>
+                    </footer>
+                </section>
+                <footer class="info">
+                    <p>"Double-click to edit a todo"</p>
+                    <p>"Written by " <a href="https://github.com/ivanceras/" target="_blank">"Jovansonlee Cesar"</a></p>
+                    <p>"Part of " <a href="http://todomvc.com/" target="_blank">"TodoMVC"</a></p>
+                </footer>
+            </div>
+        }
     }
 }
 
 impl Model {
     fn view_filter(&self, filter: Filter) -> Node<Msg> {
-        let flt = filter.clone();
-        li(
-            vec![],
-            vec![a(
-                vec![
-                    class(if self.filter == flt {
-                        "selected"
-                    } else {
-                        "not-selected"
-                    }),
-                    href(flt.to_string()),
-                    on_click(move |_| Msg::SetFilter(flt.clone())),
-                ],
-                vec![text(filter.to_string())],
-            )],
-        )
+        node! {
+            <li class={if self.filter == filter {
+                "selected"
+            } else {
+                "not-selected"
+            }}
+            href={filter.to_string()}
+            on_click={move |_| Msg::SetFilter(filter)}>
+                {text(filter.to_string())}
+            </li>
+        }
     }
 
     fn view_input(&self) -> Node<Msg> {
-        input(
-            vec![
-                class("new-todo"),
-                id("new-todo"),
-                placeholder("What needs to be done?"),
-                value(self.value.to_string()),
-                on_input(|v: InputEvent| Msg::Update(v.value.to_string())),
-                on_keypress(|event: KeyboardEvent| {
+        node! {
+            <input
+                class="new-todo"
+                id="new-todo"
+                placeholder="What needs to be done?"
+                value={self.value.to_string()}
+                on_input={|v: InputEvent| Msg::Update(v.value.to_string())}
+                on_keypress={|event: KeyboardEvent| {
                     if event.key() == "Enter" {
                         Msg::Add
                     } else {
                         Msg::Nope
                     }
-                }),
-            ],
-            vec![],
-        )
+                }} />
+        }
     }
 }
 
-fn view_entry((idx, entry): (usize, &Entry)) -> Node<Msg> {
-    li(
-        vec![classes_flag([
+fn view_entry(idx: usize, entry: &Entry) -> Node<Msg> {
+    node! {
+        <li {classes_flag([
             ("todo", true),
             ("editing", entry.editing),
             ("completed", entry.completed),
-        ])],
-        vec![
-            div(
-                vec![class("view")],
-                vec![
-                    input(
-                        vec![
-                            class("toggle"),
-                            r#type("checkbox"),
-                            checked(entry.completed),
-                            on_click(move |_| Msg::Toggle(idx)),
-                        ],
-                        vec![],
-                    ),
-                    label(
-                        vec![on_doubleclick(move |_| Msg::ToggleEdit(idx))],
-                        vec![text(format!("{}", entry.description))],
-                    ),
-                    button(
-                        vec![
-                            class("destroy"),
-                            on_click(move |_| Msg::Remove(idx)),
-                        ],
-                        vec![],
-                    ),
-                ],
-            ),
-            { view_entry_edit_input((idx, &entry)) },
-        ],
-    )
+        ])}>
+            <div class="view">
+                <input class="toggle" r#type="checkbox" checked={entry.completed} on_click={move |_| Msg::Toggle(idx)} />
+                <label on_doubleclick={move |_| Msg::ToggleEdit(idx)}>{text(entry.description.clone())}</label>
+                <button class="destroy" on_click={move |_| Msg::Remove(idx)} />
+            </div>
+            { view_entry_edit_input((idx, &entry)) }
+        </li>
+    }
 }
 
 fn view_entry_edit_input((idx, entry): (usize, &Entry)) -> Node<Msg> {
@@ -307,7 +218,7 @@ fn view_entry_edit_input((idx, entry): (usize, &Entry)) -> Node<Msg> {
     }
 }
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub enum Filter {
     All,
     Active,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,8 @@
 #[macro_use]
 extern crate doc_comment;
 
+pub use sauron_macros::node;
+
 use cfg_if::cfg_if;
 cfg_if! {if #[cfg(feature = "with-dom")] {
     pub mod dom;


### PR DESCRIPTION
Hey,

So this is a project I've been considering doing for a while in [genco](https://github.com/udoprog/genco). But it's not really suitable as a general purpose way to generate HTML. I came across sauron and decided to instead try and incorporate it here.

This experimental (!) PR adds support for a `node!` macro to build nodes through html-like quasi quoting, like this:

```rust
impl Model {
    fn view_input(&self) -> Node<Msg> {
        node! {
            <input
                class="new-todo"
                id="new-todo"
                placeholder="What needs to be done?"
                value={self.value.to_string()}
                on_input={|v: InputEvent| Msg::Update(v.value.to_string())}
                on_keypress={|event: KeyboardEvent| {
                    if event.key() == "Enter" {
                        Msg::Add
                    } else {
                        Msg::Nope
                    }
                }} />
        }
    }
}
```

I'm opening this PR to gauge if there's any interest in adding this to the project, or whether I should release it as an external crate. I intend to fix some missing things and add more documentation to the macro. I've also ported the TodoMVC application in case you want to take it for a spin.

#### Literal Content

Since [spans aren't stable](https://github.com/rust-lang/rust/issues/54725#issuecomment-647140141), interior text content need to be presented as text literals in order to preserve whitespace.

Like this:

```rust
<h1>"This is a title"</h1>
```

Alternatively you simply use the `text` function as before. But a literal could potentially be optimized if we add support for `&'static str` to [`Node`](https://docs.rs/mt-dom/0/mt_dom/enum.Node.html). This could mean a nice performance boon for certain applications since static strings do not need to be allocated.

If we ever get stable spans, a similar form of whitespace detection that I've implemented in genco could be used here as well to preserve whitespace and users could simply write:

```html
<h1>This is a title</h1>
```

As long as it doesn't contain illegal rust syntax.

#### Loops

I've added somewhat esoteric support for loops, where each value in the block is added as a child (making this sort of a limited templating). I do something similar in genco, and I personally find it nicer than producing a `Vec<Node>` manually.

```rust
<ul class="todo-list">
    {for (i, e) in self.entries.iter().filter(|e| self.filter.fit(e)).enumerate() {
        view_entry(i, e)
    }}
</ul>
```

If you find this too odd, this can be removed.

#### TODO

* [x] Write more documentation and examples.
  * [x] Child interpolation.
  * [x] Child loops.
  * [x] Attribute interpolation.
* [x] Add support for value-less attributes (like `<button disabled>`).
* [ ] Consider adding a custom conversion trait (example name: `AddToNode`) which would allow for more custom conversion, like `Option<T> where T: AddToNode`. [Something similar](https://docs.rs/genco/0.15.0/genco/prelude/trait.FormatInto.html) exists in genco.