### PR TITLE
Refactor node macro to use syn-rsx as parser

### DIFF
--- a/crates/sauron-node-macro/Cargo.toml
+++ b/crates/sauron-node-macro/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 syn = { version = "1.0.40", features = ["full"] }
-syn-rsx = { git = "https://github.com/stoically/syn-rsx", branch = "main" }
+syn-rsx = { version = "0.7.1" }
 quote = {package = "quote", version = "1.0.3"}
 proc-macro2 = { version = "1.0.10" }
 

--- a/crates/sauron-node-macro/Cargo.toml
+++ b/crates/sauron-node-macro/Cargo.toml
@@ -11,12 +11,13 @@ keywords = ["html", "dom", "web"]
 edition = "2018"
 
 [dependencies]
-syn = { version = "1.0.31", features = ["full"] }
+syn = { version = "1.0.40", features = ["full"] }
+syn-rsx = { git = "https://github.com/stoically/syn-rsx", branch = "main" }
 quote = {package = "quote", version = "1.0.3"}
 proc-macro2 = { version = "1.0.10" }
 
 [dev-dependencies]
-sauron = { path = "../../" }
+sauron = { path = "../../", default-features = false, features = ["with-dom"] }
 
 [lib]
 proc-macro = true

--- a/crates/sauron-node-macro/src/lib.rs
+++ b/crates/sauron-node-macro/src/lib.rs
@@ -1,7 +1,4 @@
-#![recursion_limit = "256"]
 #![doc(html_root_url = "https://docs.rs/sauron/0.28.2")]
-
-use quote::ToTokens as _;
 
 extern crate proc_macro;
 
@@ -21,8 +18,9 @@ mod node;
 ///
 /// ```rust
 /// use sauron::*;
+/// # use sauron_node_macro::node;
 ///
-/// let _: Node<()> = node!(<input type_="button" />);
+/// let _: Node<()> = node!(<input type="button" />);
 /// let _: Node<()> = node!(<h1>"A title"</h1>);
 /// ```
 ///
@@ -36,6 +34,7 @@ mod node;
 ///
 /// ```rust
 /// use sauron::*;
+/// # use sauron_node_macro::node;
 ///
 /// let _: Node<()> = node!(<input x_data_="my data" />);
 /// let _: Node<()> = node!(<input x_data_int_=42u32 x_data_bool_=true />);
@@ -46,6 +45,7 @@ mod node;
 ///
 /// ```rust
 /// use sauron::*;
+/// # use sauron_node_macro::node;
 ///
 /// struct Model {
 ///     value: String,
@@ -63,6 +63,7 @@ mod node;
 ///
 /// ```rust
 /// use sauron::{*, html::*,html::attributes::*};
+/// # use sauron_node_macro::node;
 ///
 /// struct Model {
 ///     editing: bool,
@@ -84,6 +85,7 @@ mod node;
 ///
 /// ```rust
 /// use sauron::*;
+/// # use sauron_node_macro::node;
 ///
 /// let _: Node<()> = node!(<button disabled />);
 /// ```
@@ -98,6 +100,7 @@ mod node;
 ///
 /// ```rust
 /// use sauron::*;
+/// # use sauron_node_macro::node;
 ///
 /// enum Msg {
 ///     Update(String),
@@ -142,6 +145,7 @@ mod node;
 ///
 /// ```rust
 /// use sauron::{*,html::text};
+/// # use sauron_node_macro::node;
 ///
 /// struct Model {
 ///     items: Vec<String>,
@@ -167,6 +171,5 @@ mod node;
 /// the library to have collision with the `html` tag, when used as tag macro
 #[proc_macro]
 pub fn node(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let node = syn::parse_macro_input!(input as node::Node);
-    node.to_token_stream().into()
+    node::to_token_stream(input).into()
 }

--- a/crates/sauron-node-macro/src/node.rs
+++ b/crates/sauron-node-macro/src/node.rs
@@ -1,322 +1,191 @@
 use proc_macro2::{Span, TokenStream};
-use quote::ToTokens;
-use syn::{
-    ext::IdentExt as _,
-    parse::{Parse, ParseStream},
-    token, Error, Expr, ExprForLoop, Ident, Lit, LitStr, Token,
-};
+use quote::quote;
+use syn::{Expr, ExprBlock, ExprForLoop, Ident, Stmt};
+use syn_rsx::{Node, NodeType};
 
-pub(super) struct Node {
-    name: Ident,
-    attrs: Vec<Attribute>,
-    children: Vec<Child>,
-}
-
-impl Node {
-    /// Parse an opening node.
-    fn parse_open(
-        input: ParseStream,
-    ) -> syn::Result<(bool, Ident, Vec<Attribute>)> {
-        input.parse::<Token![<]>()?;
-        let element = input.parse::<Ident>()?;
-
-        let mut attrs = Vec::new();
-
-        while !input.is_empty() {
-            if input.peek(Token![>]) {
-                input.parse::<Token![>]>()?;
-                return Ok((true, element, attrs));
+pub fn to_token_stream(input: proc_macro::TokenStream) -> TokenStream {
+    match syn_rsx::parse(input, None) {
+        Ok(mut nodes) => {
+            if nodes.len() != 1 {
+                return quote! {
+                    compile_error!("Exactly one top level node is required")
+                };
             }
-
-            if input.peek(Token![/]) && input.peek2(Token![>]) {
-                input.parse::<Token![/]>()?;
-                input.parse::<Token![>]>()?;
-                return Ok((false, element, attrs));
+            let node = nodes.pop().unwrap();
+            match node.node_type {
+                NodeType::Element => node_to_tokens(node),
+                _ => quote! {
+                    compile_error!("Top level node needs to be an element")
+                },
             }
-
-            attrs.push(input.parse()?);
         }
-
-        Err(input.error(format!("Expected closing of element `{}`", element)))
-    }
-
-    fn children_to_tokens(&self, receiver: &Ident, tokens: &mut TokenStream) {
-        if !self.children.is_empty() {
-            let count = self.children.len();
-
-            tokens.extend(quote::quote! {
-                let mut #receiver = Vec::with_capacity(#count);
-            });
-
-            for c in &self.children {
-                match c {
-                    Child::Node(node) => {
-                        tokens.extend(quote::quote! {
-                            #receiver.push(#node);
-                        });
-                    }
-                    Child::LitStr(s) => {
-                        tokens.extend(quote::quote! {
-                            #receiver.push(sauron::Node::Text(String::from(#s)));
-                        });
-                    }
-                    Child::Eval(e) => {
-                        tokens.extend(quote::quote! {
-                            #receiver.push(sauron::Node::from(#e));
-                        });
-                    }
-                    Child::Loop(ExprForLoop {
-                        pat, expr, body, ..
-                    }) => {
-                        tokens.extend(quote::quote! {
-                            for #pat in #expr {
-                                #receiver.push(sauron::Node::from(#body));
-                            }
-                        });
-                    }
-                }
-            }
-        } else {
-            tokens.extend(quote::quote! {
-                let #receiver = Vec::new();
-            });
-        }
+        Err(error) => error.to_compile_error(),
     }
 }
 
-impl Parse for Node {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
-        let mut children = Vec::new();
+fn node_to_tokens(node: Node) -> TokenStream {
+    let mut tokens = TokenStream::new();
 
-        if !input.peek(Token![<]) {
-            return Err(input.error("expected opening caret"));
-        }
+    // NodeType::Element nodes can't have no name
+    let name = node.name_as_string().unwrap();
 
-        let (is_open, name, attrs) = Self::parse_open(input)?;
+    let mut attributes = vec![];
+    for attribute in &node.attributes {
+        attributes.push(attribute_to_tokens(attribute));
+    }
 
-        if is_open {
-            loop {
-                // Parse end node.
-                if input.peek(Token![<]) && input.peek2(Token![/]) {
-                    input.parse::<Token![<]>()?;
-                    input.parse::<Token![/]>()?;
-                    let end = input.parse::<Ident>()?;
-                    input.parse::<Token![>]>()?;
+    let children_tokens = children_to_tokens(node.children);
 
-                    if name != end {
-                        return Err(Error::new(
-                            end.span(),
-                            format!(
-                                "Closing node `{}` does not match open node `{}`",
-                                end, name
-                            ),
-                        ));
+    tokens.extend(quote! {{
+        let attrs = vec![#(#attributes),*];
+        #children_tokens
+        sauron::html::html_element(#name, attrs, children)
+    }});
+
+    tokens
+}
+
+fn attribute_to_tokens(attribute: &Node) -> TokenStream {
+    match &attribute.value {
+        Some(value) => {
+            match attribute.node_type {
+                NodeType::Block => {
+                    quote! {
+                        sauron::Attribute::from(#value)
                     }
-
-                    break;
                 }
+                NodeType::Attribute => {
+                    // NodeType::Attribute nodes can't have no name
+                    let name = attribute.name_as_string().unwrap();
 
-                if input.is_empty() {
-                    return Err(input.error(format!(
-                        "Expected closing of element `{}`",
-                        name
-                    )));
-                }
-
-                if input.peek(LitStr) {
-                    children.push(Child::LitStr(input.parse()?));
-                } else if input.peek(token::Brace) {
-                    let content;
-                    let _ = syn::braced!(content in input);
-
-                    let child = if content.peek(Token![for]) {
-                        let for_loop = content.parse::<ExprForLoop>()?;
-                        Child::Loop(for_loop)
+                    if name.starts_with("on_") {
+                        let name = quote::format_ident!("{}", name);
+                        quote::quote! {
+                            sauron::events::#name(#value)
+                        }
                     } else {
-                        Child::Eval(content.parse()?)
-                    };
-
-                    children.push(child);
-                } else {
-                    children.push(Child::Node(input.parse()?));
+                        let name = convert_name(&name);
+                        quote::quote! {
+                            sauron::Attribute::new(
+                                None,
+                                #name,
+                                sauron::html::attributes::AttributeValue::Simple(
+                                    sauron::html::attributes::Value::from(#value)
+                                )
+                            )
+                        }
+                    }
+                }
+                _ => {
+                    quote! {
+                        compile_error!("Unexpected NodeType")
+                    }
                 }
             }
         }
-
-        Ok(Node {
-            name,
-            attrs,
-            children,
-        })
-    }
-}
-
-impl ToTokens for Node {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        let name = LitStr::new(&self.name.to_string(), self.name.span());
-        let attrs = &self.attrs;
-
-        let receiver = Ident::new("children", Span::call_site());
-        let mut children_tokens = TokenStream::new();
-        self.children_to_tokens(&receiver, &mut children_tokens);
-
-        tokens.extend(quote::quote! {{
-            let attrs = vec![#(#attrs),*];
-            #children_tokens
-            sauron::html::html_element(#name, attrs, children)
-        }});
-    }
-}
-
-enum Attribute {
-    Event {
-        name: Ident,
-        value: Expr,
-    },
-    /// A literal attribute.
-    ///
-    /// Like `<button style="border: 1px solid red;">`.
-    Lit {
-        name: LitStr,
-        value: Lit,
-    },
-    /// An expression attribute.
-    ///
-    /// The expression is expected to evaluate to a attribute `Value`.
-    ///
-    /// Like `<button style={style()}>`.
-    Expr {
-        name: LitStr,
-        value: Expr,
-    },
-    /// An empty attribute.
-    ///
-    /// Like `<button disabled>`.
-    Empty {
-        name: LitStr,
-    },
-    /// An expression expected to generate an attribute.
-    AttributeExpr {
-        value: Expr,
-    },
-}
-
-impl Attribute {
-    /// Convert a name `n` from lower_camel to kebab-case.
-    fn convert_name(n: &str) -> String {
-        let mut out = String::with_capacity(n.len());
-
-        for c in n.trim_matches('_').chars() {
-            match c {
-                '_' => out.push('-'),
-                c => out.push(c),
+        None => {
+            let name = convert_name(&attribute.name_as_string().unwrap());
+            quote! {
+                sauron::Attribute::new(
+                    None,
+                    #name,
+                    sauron::html::attributes::AttributeValue::Empty,
+                )
             }
         }
-
-        out
     }
 }
 
-impl Parse for Attribute {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
-        if input.peek(token::Brace) {
-            let content;
-            let _ = syn::braced!(content in input);
-            let value = content.parse()?;
-            return Ok(Self::AttributeExpr { value });
-        }
+fn children_to_tokens(children: Vec<Node>) -> TokenStream {
+    let receiver = Ident::new("children", Span::call_site());
+    let mut tokens = TokenStream::new();
+    if !children.is_empty() {
+        let count = children.len();
 
-        let name = input.parse::<Ident>()?.unraw();
+        tokens.extend(quote! {
+            let mut #receiver = Vec::with_capacity(#count);
+        });
 
-        let event = match name.to_string().as_str() {
-            n if n.starts_with("on_") => true,
-            _ => false,
-        };
-
-        if event {
-            input.parse::<Token![=]>()?;
-
-            let content;
-            let _ = syn::braced!(content in input);
-
-            let value = content.parse()?;
-            Ok(Self::Event { name, value })
-        } else {
-            let name = LitStr::new(
-                &Self::convert_name(&name.to_string()),
-                name.span(),
-            );
-
-            if input.peek(Token![=]) {
-                input.parse::<Token![=]>()?;
-
-                if input.peek(token::Brace) {
-                    let content;
-                    let _ = syn::braced!(content in input);
-                    let value = content.parse()?;
-                    Ok(Self::Expr { name, value })
-                } else {
-                    let value = input.parse()?;
-                    Ok(Self::Lit { name, value })
+        for child in children {
+            match child.node_type {
+                NodeType::Element => {
+                    let node = node_to_tokens(child);
+                    tokens.extend(quote! {
+                        #receiver.push(#node);
+                    });
                 }
-            } else {
-                Ok(Self::Empty { name })
+                NodeType::Text => {
+                    let s = child.value_as_string().unwrap();
+                    tokens.extend(quote! {
+                        #receiver.push(sauron::Node::Text(String::from(#s)));
+                    });
+                }
+                NodeType::Block => match child.value {
+                    Some(syn::Expr::Block(expr)) => {
+                        match braced_for_loop(&expr) {
+                            Some(ExprForLoop {
+                                pat, expr, body, ..
+                            }) => {
+                                tokens.extend(quote! {
+                                        for #pat in #expr {
+                                            #receiver.push(sauron::Node::from(#body));
+                                        }
+                                    });
+                            }
+                            _ => {
+                                tokens.extend(quote! {
+                                    #receiver.push(sauron::Node::from(#expr));
+                                });
+                            }
+                        }
+                    }
+                    _ => {
+                        return quote! {
+                            compile_error!("Unexpected missing block for NodeType::Block")
+                        }
+                    }
+                },
+                _ => {
+                    return quote! {
+                        compile_error!(format!("Unexpected NodeType for child: {}", child.node_type))
+                    }
+                }
             }
+        }
+    } else {
+        tokens.extend(quote! {
+            let #receiver = Vec::new();
+        });
+    }
+
+    tokens
+}
+
+fn braced_for_loop<'a>(expr: &'a ExprBlock) -> Option<&'a ExprForLoop> {
+    let len = expr.block.stmts.len();
+    if len != 1 {
+        None
+    } else {
+        let stmt = &expr.block.stmts[0];
+        match stmt {
+            Stmt::Expr(expr) => match expr {
+                Expr::ForLoop(expr) => Some(expr),
+                _ => None,
+            },
+            _ => None,
         }
     }
 }
 
-impl ToTokens for Attribute {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        match self {
-            Self::Lit { name, value } => {
-                tokens.extend(quote::quote! {
-                    sauron::Attribute::new(
-                        None,
-                        #name,
-                        sauron::html::attributes::AttributeValue::Simple(
-                            sauron::html::attributes::Value::from(#value)
-                        )
-                    )
-                });
-            }
-            Self::Expr { name, value } => {
-                tokens.extend(quote::quote! {
-                    sauron::Attribute::new(
-                        None,
-                        #name,
-                        sauron::html::attributes::AttributeValue::Simple(
-                            sauron::html::attributes::Value::from(#value)
-                        )
-                    )
-                });
-            }
-            Self::Empty { name } => {
-                tokens.extend(quote::quote! {
-                    sauron::Attribute::new(
-                        None,
-                        #name,
-                        sauron::html::attributes::AttributeValue::Empty,
-                    )
-                });
-            }
-            Self::Event { name, value } => {
-                tokens.extend(quote::quote! {
-                    sauron::events::#name(#value)
-                });
-            }
-            Self::AttributeExpr { value } => {
-                tokens.extend(quote::quote! {
-                    sauron::Attribute::from(#value)
-                });
-            }
+fn convert_name(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+
+    for c in name.trim_matches('_').chars() {
+        match c {
+            '_' => out.push('-'),
+            c => out.push(c),
         }
     }
-}
 
-enum Child {
-    Node(Node),
-    LitStr(LitStr),
-    Eval(Expr),
-    Loop(ExprForLoop),
+    out
 }

--- a/examples/minimal-macro-syntax/src/lib.rs
+++ b/examples/minimal-macro-syntax/src/lib.rs
@@ -27,7 +27,7 @@ impl Component<Msg> for App {
                 <h1>"Minimal example"</h1>
                 <div class="some-class" id="some-id" {attr("data-id", 1)}>
                     <input class="client"
-                            type_="button"
+                            type="button"
                             value="Click me!"
                             key=1
                             on_click={|_| {
@@ -36,7 +36,7 @@ impl Component<Msg> for App {
                             }}
                     />
                     <div>{text(format!("Clicked: {}", self.click_count))}</div>
-                    <input type_="text" value={self.click_count}/>
+                    <input type="text" value={self.click_count}/>
                 </div>
             </main>
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 //!                 <h1>"Minimal example"</h1>
 //!                 <div class="some-class" id="some-id" {attr("data-id", 1)}>
 //!                     <input class="client"
-//!                             type_="button"
+//!                             type="button"
 //!                             value="Click me!"
 //!                             key=1
 //!                             on_click={|_| {
@@ -50,7 +50,7 @@
 //!                             }}
 //!                     />
 //!                     <div>{text(format!("Clicked: {}", self.click_count))}</div>
-//!                     <input type_="text" value={self.click_count}/>
+//!                     <input type="text" value={self.click_count}/>
 //!                 </div>
 //!             </main>
 //!         }


### PR DESCRIPTION
Here's a WIP proposal to show how using [`syn-rsx`](https://docs.rs/syn-rsx/) as mentioned in #15 would work.

Benefits:

- Supports reserved keywords as tag/attribute names (so `<input type="button" />` works)
- Supports dashes and colons in tag/attribute names (so commonly used attributes like `data-foo="bar"` work)
- Helpful error messages for some tricky edge cases
- Parsing HTML and generating sauron code is clearly separated
- Multiple web frameworks depending on syn-rsx would allow to join forces around ironing out the details when parsing

Todo

- [ ] Currently doc examples need to explicitly import the macro module since fully importing sauron ends up with rust choking on 
  > note: perhaps two different versions of crate syn are being used?

  Not sure yet why that's the case, `cargo-tree -e all -i -p syn` looks fine

- [x] Move the "one top level element node"-check as `ParserConfig` option into syn-rsx
- [x] Publish new syn-rsx version with the block-as-attribute feature and switch to crates.io version

If you don't feel like pulling in a dependency for this, of course feel free to close

cc @udoprog 