### PR TITLE
SSR example

### DIFF
--- a/examples/server-side-rendering/Cargo.toml
+++ b/examples/server-side-rendering/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+
+members = [
+    "server",
+    "client"
+]

--- a/examples/server-side-rendering/build.sh
+++ b/examples/server-side-rendering/build.sh
@@ -1,0 +1,1 @@
+cd client && wasm-pack build --target web --out-dir static && cd ..

--- a/examples/server-side-rendering/client/Cargo.toml
+++ b/examples/server-side-rendering/client/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "client"
+version = "0.1.0"
+authors = ["Greg Johnston <greg.johnston@gmail.com>"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+wasm-bindgen = "0.2.29"
+sauron = "0.31"
+console_error_panic_hook = { version = "0.1"}
+log = "0.4"
+console_log = {version ="0.2", features = ["color"]}
+serde = { version = "1.0", features = ["serde_derive"]}
+serde_json = "1.0"

--- a/examples/server-side-rendering/client/src/lib.rs
+++ b/examples/server-side-rendering/client/src/lib.rs
@@ -27,6 +27,7 @@ pub struct Data {
     pub modified_name: String,
 }
 
+// App and all its members should be Serializable by serde
 #[derive(Debug, Deserialize, Serialize)]
 pub struct App {
     pub name: String,
@@ -144,12 +145,16 @@ pub fn main(serialized_state: String) {
     console_log::init_with_level(log::Level::Trace).unwrap();
     console_error_panic_hook::set_once();
 
+    /* Deserialize starting app data from the argument, which is passed in index.html
+     * (but generated in server/src/main.rs) */
     let mut app = App::new();
     if let Ok(state) = serde_json::from_str::<App>(&serialized_state) {
        app.name = state.name;
        app.data = state.data;
     };
 
+    /* If there's a window (i.e., if this is running in the browser)
+     * then mount the app by swapping out the <main> tag */
     match web_sys::window() {
         Some(window) => {
             trace!("found window, will try to replace <main>");

--- a/examples/server-side-rendering/client/src/lib.rs
+++ b/examples/server-side-rendering/client/src/lib.rs
@@ -1,0 +1,164 @@
+use sauron::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[macro_use]
+extern crate log;
+
+const DATA_URL: &'static str = "http://localhost:3030/api";
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum FetchStatus<T> {
+    Idle(T),
+    Loading,
+    Complete(T),
+    Error(Option<String>)
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum Msg {
+    EditName(String),
+    ReceivedData(Result<Data, JsValue>),
+    QueryAPI
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
+pub struct Data {
+    pub length: usize,
+    pub modified_name: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct App {
+    pub name: String,
+    pub data: FetchStatus<Data>,
+    error: Option<String>
+}
+
+impl App {
+    pub fn new() -> Self {
+        App {
+            name: String::from(""),
+            data: FetchStatus::Idle(Data {
+                length: 0,
+                modified_name: String::from("")
+            }),
+            error: None
+        }
+    }
+
+    fn fetch_data(&self) -> Cmd<Self, Msg> {
+        let url = format!("{}/{}", DATA_URL, self.name);
+        Http::fetch_with_text_response_decoder(
+            &url,
+            |v: String| {
+                let data: Result<Data, _> = serde_json::from_str(&v);
+                trace!("data: {:#?}", data);
+                data.expect("Error deserializing data")
+            },
+            Msg::ReceivedData,
+        )
+    }
+}
+
+impl Component<Msg> for App {
+    fn init(&self) -> Cmd<Self, Msg> {
+        Cmd::none()
+    }
+
+    fn view(&self) -> Node<Msg> {
+        node! {
+            <main>
+                <form on_submit={|e| {
+                    e.prevent_default();
+                    Msg::QueryAPI
+                }}>
+                    <label>
+                        "What’s your name, man?"
+                        <input
+                            type_="text"
+                            value={&self.name}
+                            on_input={|e| Msg::EditName(e.value)}
+                        />
+                    </label>
+                    <button type_="submit">"Okay!"</button>
+                </form>
+                {self.view_data()}
+            </main>
+        }
+    }
+
+    fn update(&mut self, msg: Msg) -> Cmd<Self, Msg> {
+        trace!("App is updating from msg: {:?}", msg);
+        let mut cmd = Cmd::none();
+        match msg {
+            Msg::EditName(name) => self.name = name,
+            Msg::QueryAPI => {
+                self.data = FetchStatus::Loading;
+                cmd = self.fetch_data()
+            },
+            Msg::ReceivedData(Ok(data)) => self.data = FetchStatus::Complete(data),
+            Msg::ReceivedData(Err(js_value)) => {
+                trace!("Error fetching data! {:#?}", js_value);
+                self.data = FetchStatus::Error(Some(format!(
+                    "There was an error reaching the api: {:?}",
+                    js_value
+                )));
+            }
+        };
+        cmd
+    }
+}
+
+impl App {
+    fn view_data(&self) -> Node<Msg> {
+        match &self.data {
+            FetchStatus::Idle(_) => node! { <p>"Waiting around..."</p> },
+            FetchStatus::Error(Some(e)) => node! {
+                <article>
+                    <p>"Okay, something went wrong. I think it was: "</p>
+                    <code>{text(e)}</code>
+                </article>
+            },
+            FetchStatus::Error(None) => node! {
+                <article>
+                    <p>"Okay, something went wrong. I have no idea what it is."</p>
+                </article>
+            },
+            FetchStatus::Loading => node! {
+                <article>
+                    <p>"Loading..."</p>
+                </article>
+            },
+            FetchStatus::Complete(data) => node! {
+                <article>
+                    <p>"Hello, "<span class="modified-name">{text(&data.modified_name)}</span></p>
+                    <p>"Hey, did you know that’s "<span class="length">{text(&data.length)}</span>" characters long?"</p>
+                </article>
+            },
+        }
+    }
+}
+
+#[wasm_bindgen]
+pub fn main(serialized_state: String) {
+    console_log::init_with_level(log::Level::Trace).unwrap();
+    console_error_panic_hook::set_once();
+
+    let mut app = App::new();
+    if let Ok(state) = serde_json::from_str::<App>(&serialized_state) {
+       app.name = state.name;
+       app.data = state.data;
+    };
+
+    match web_sys::window() {
+        Some(window) => {
+            trace!("found window, will try to replace <main>");
+            let document = window.document().expect("should have a document on window");
+            Program::new_replace_mount(app, &document.query_selector_all("main").unwrap().get(0).unwrap());
+        }
+        None => {
+            trace!("window not found");
+            Program::mount_to_body(app);
+        }
+    }
+}

--- a/examples/server-side-rendering/run.sh
+++ b/examples/server-side-rendering/run.sh
@@ -1,0 +1,1 @@
+cargo run --bin server

--- a/examples/server-side-rendering/server/Cargo.toml
+++ b/examples/server-side-rendering/server/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "server"
+version = "0.1.0"
+authors = ["Greg Johnston <greg.johnston@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+warp = "0.2"
+sauron = "0.31"
+tokio = { version = "0.2", features = ["full"] }
+serde_json = "1.0"
+
+client = { path = "../client" }

--- a/examples/server-side-rendering/server/src/main.rs
+++ b/examples/server-side-rendering/server/src/main.rs
@@ -3,6 +3,7 @@ use serde_json;
 use client::{App, Data, FetchStatus};
 use sauron::prelude::*;
 
+// Replace this with whatever data you're actually trying to return
 fn fake_api_call(name: String) -> Data {
     Data {
         length: name.len(),
@@ -10,7 +11,9 @@ fn fake_api_call(name: String) -> Data {
     }
 }
 
+// path relative to the working directory when you run the server binary
 const STATIC_DIR: &str = "client/static";
+// path relative to this file
 static INDEX_HTML: &'static str = include_str!("../../client/static/index.html");
 
 #[tokio::main]
@@ -20,31 +23,40 @@ async fn main() {
             serde_json::to_string(&fake_api_call(name)).unwrap()
         });
     
+    // Static assets: CSS, JS, etc.
     let static_files = warp::path("static")
         .and(warp::fs::dir(STATIC_DIR));
 
     let render_page = |name: String| {
-        let mut buffer = String::new();
+        // initialize blank app state
         let mut app = App::new();
-        app.name = name.clone();
 
+        // Fetch API data for the argument and stuff it into the app
+        app.name = name.clone();
         let api_data = fake_api_call(name);
         app.data = FetchStatus::Complete(api_data);
 
+        // Serialize the state 
         let serialized_state = serde_json::to_string(&app).unwrap();
 
+        // Render the app into a String buffer
         let node = app.view();
+        let mut buffer = String::new();
         node.render(&mut buffer).expect("must render");
 
+        // Render the page
         let rendered_index_page = INDEX_HTML
             .replace("<main></main>", &buffer)
+            // pass the serialized state as argument to the main() function, defined in client/src/lib.rs
             .replace("main(``);", &format!("main(`{}`);", serialized_state));
         Response::builder().body(rendered_index_page)
     };
 
+    // Render paths that include a name argument
     let named = warp::path!(String)
         .map(render_page);
 
+    // Render paths that don't include a name with a default
     let root = warp::path::end()
         .map(move || render_page(String::from("Ferris")));
 

--- a/examples/server-side-rendering/server/src/main.rs
+++ b/examples/server-side-rendering/server/src/main.rs
@@ -1,0 +1,61 @@
+use warp::{Filter, http::Response};
+use serde_json;
+use client::{App, Data, FetchStatus};
+use sauron::prelude::*;
+
+fn fake_api_call(name: String) -> Data {
+    Data {
+        length: name.len(),
+        modified_name: name.to_uppercase(),
+    }
+}
+
+const STATIC_DIR: &str = "client/static";
+static INDEX_HTML: &'static str = include_str!("../../client/static/index.html");
+
+#[tokio::main]
+async fn main() {
+    let api_call = warp::path!("api" / String)
+        .map(|name| {
+            serde_json::to_string(&fake_api_call(name)).unwrap()
+        });
+    
+    let static_files = warp::path("static")
+        .and(warp::fs::dir(STATIC_DIR));
+
+    let render_page = |name: String| {
+        let mut buffer = String::new();
+        let mut app = App::new();
+        app.name = name.clone();
+
+        let api_data = fake_api_call(name);
+        app.data = FetchStatus::Complete(api_data);
+
+        let serialized_state = serde_json::to_string(&app).unwrap();
+
+        let node = app.view();
+        node.render(&mut buffer).expect("must render");
+
+        let rendered_index_page = INDEX_HTML
+            .replace("<main></main>", &buffer)
+            .replace("main(``);", &format!("main(`{}`);", serialized_state));
+        Response::builder().body(rendered_index_page)
+    };
+
+    let named = warp::path!(String)
+        .map(render_page);
+
+    let root = warp::path::end()
+        .map(move || render_page(String::from("Ferris")));
+
+    let routes = warp::get().and(
+        root
+        .or(named)
+        .or(api_call)
+        .or(static_files)
+    );
+
+    warp::serve(routes)
+        .run(([127, 0, 0, 1], 3030))
+        .await;
+}


### PR DESCRIPTION
Per #22, here's a basic example of using how someone could render their whole app state on the server, and then seamlessly transition to client-side rendering. Should be pretty self-explanatory: `./build.sh && ./run.sh` and open a browser at `localhost:3030`. 