### PR TITLE
Updated macro to support better handling of disabled attribute

### DIFF
--- a/crates/sauron-node-macro/src/node.rs
+++ b/crates/sauron-node-macro/src/node.rs
@@ -78,6 +78,10 @@ fn attribute_to_tokens(attribute: &Node) -> TokenStream {
                         quote::quote! {
                             sauron::events::#name(#value)
                         }
+                    } else if name.eq("disabled") {
+                       quote::quote! {
+                           sauron::html::attributes::disabled(#value)
+                       } 
                     } else {
                         let name = convert_name(&name);
                         quote::quote! {


### PR DESCRIPTION
When using the node! macro I had the expectation that the disabled attribute on input tag would be toggleable.

```
// Taken from fetch-data example
<input 
  class="next_page" 
  type="button" 
  disabled={self.page >= self.data.total_pages}
  value="Next Page >>"
  on_click=|_| {
      trace!("button is clicked");
      Msg::PrevPage
  }
/>
```


This is not what I experienced. After running cargo expand it appeared to use the attribute and value directly in an html attribute.

```
// Cargo expand
sauron::html::attributes::attr(
  disabled",
  self.page >= self.data.total_pages},
)
```

Given that the HTML attribute [must be absent](https://www.w3schools.com/tags/att_button_disabled.asp) for it to remain enabled this is the behavior I expected.

```
Expected cargo expand
sauron::Attribute::from({
  if self.page <= 1 {
    attr("disabled", true)
  else {
    empty_attr()
  }
})
```

In this commit I add a condition in `attribute_to_tokens` to do an equality check against the name of the attribute and invoke the same behavior as `sauron::html::attributes::disabled()`

```
// Resulting cargo expand
sauron::html::attributes::disabled({ self . page >= self . data . total_pages })
```

The code also becomes much more condensed after this change.

```
<input
  type="button"
  disabled={self.page <= 1}
  ...

// vs

<input 
  type="button" 
  {
    if self.page <= 1 {
    	attr("disabled", true)
    } else {
    	empty_attr()
    }
  }
...
```