### PR TITLE
Correctly set value on HtmlSelectElement and HtmlOptionElement

### DIFF
--- a/crates/sauron-core/src/dom/created_node.rs
+++ b/crates/sauron-core/src/dom/created_node.rs
@@ -464,11 +464,9 @@ impl CreatedNode {
     //    web_sys::HtmlDataElement::set_value
     //    web_sys::HtmlLiElement::set_value
     //    web_sys::HtmlMeterElement::set_value
-    //    web_sys::HtmlOptionElement::set_value
     //    web_sys::HtmlOutputElement::set_value
     //    web_sys::HtmlParamElement::set_value
     //    web_sys::HtmlProgressElement::set_value
-    //    web_sys::HtmlSelectElement::set_value
     //    web_sys::RadioNodeList::set_value
     //    web_sys::SvgAngle::set_value
     //    web_sys::SvgLength::set_value
@@ -479,6 +477,12 @@ impl CreatedNode {
         } else if let Some(textarea) = element.dyn_ref::<HtmlTextAreaElement>()
         {
             textarea.set_value(value);
+        } else if let Some(select) = element.dyn_ref::<HtmlSelectElement>()
+        {
+            select.set_value(value);
+        } else if let Some(option) = element.dyn_ref::<HtmlOptionElement>()
+        {
+            option.set_value(value);
         }
     }
 


### PR DESCRIPTION
Fixes issue #48 

I made minimal changes here; quite a few of the other elements in the TODO list in the comment have `set_value` functions that take `f64` or another non-`&str` value, so I didn't want to make any assumptions about how you'd want to handle those.