### PR TITLE
Link to github actions instead of travis for CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 
 [![Latest Version](https://img.shields.io/crates/v/sauron.svg)](https://crates.io/crates/sauron)
-[![Build Status](https://travis-ci.org/ivanceras/sauron.svg?branch=master)](https://travis-ci.org/ivanceras/sauron)
+[![Build Status](https://img.shields.io/github/workflow/status/ivanceras/sauron/Rust)](https://github.com/ivanceras/sauron/actions/workflows/rust.yml)
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
 ![sauron](https://raw.githubusercontent.com/ivanceras/sauron/master/assets/sauron.png)


### PR DESCRIPTION
Cleaning up that failing badge that no longer updates (as the linked travis-ci setup is defunct).  Since shields.io is already being used for other badges, I opted to use that to maintain consistency, otherwise https://github.com/ivanceras/sauron/actions/workflows/rust.yml/badge.svg?branch=master may be used instead, though the label in the `rust.yml` file would need to be updated (which would also necessitate updating the shields.io link).