### PR TITLE
docs: update version in getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -81,13 +81,13 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-sauron = "0.50.0"
+sauron = "0.60.0"
 ```
 Next, we modify `src/lib.rs` with our application code.
 This will just display a "hello" text inside a paragraph.
 
 ```rust
-use sauron::prelude::*;
+use sauron::{node, wasm_bindgen, Application, Cmd, Node, Program};
 
 struct App;
 


### PR DESCRIPTION
Hi @ivanceras,

First of all, this project looks really interesting! I'm going to port a project of mine to Sauron to see what it's like, but it looks promising. Keep it up!

I followed the Getting Started guide and wanted to use `0.60.0` instead of `0.50.0`, but the example code for `src/lib.rs` code wouldn't compile; rust could not find `node`. I'm assuming `sauron::prelude::*` has changed since `0.50.0`.

This commit contains the changes to the file which made it work for me.