### PR TITLE
fix: disables serde-serializer feature from wasm-bindgen dep

### DIFF
--- a/crates/sauron-core/Cargo.toml
+++ b/crates/sauron-core/Cargo.toml
@@ -32,7 +32,6 @@ phf = { version = "0.11.2", features = ["macros"] }
 version = "0.2"
 optional = true
 features = [
-    "serde-serialize",
     "enable-interning",
 ]
 


### PR DESCRIPTION
👋🏼 hi! i hope this unannounced PR is fine.

this looks to disable the `serde-serialize` feature from the `wasm-bindgen` dep on `sauron-core`, which looks like was added about 3 years ago and is now unused. the reason for this is to break a possible dependency cycle as explained in https://github.com/rustwasm/wasm-bindgen/issues/2770. i'm a bit of a novice when it comes to rust, but from what i can tell there are no uses of `into_serde` (https://github.com/rustwasm/wasm-bindgen/blob/a03d23bd16cb9b1706a71f20ba062e5532b369ec/src/lib.rs#L249-L258) or `from_serde` anymore (https://github.com/rustwasm/wasm-bindgen/blob/a03d23bd16cb9b1706a71f20ba062e5532b369ec/src/lib.rs#L218-L224).

ran `just test-all` and all passed on a darwin arm64 host ✅