### PR TITLE
Fix typo in documentation for Cmd

### DIFF
--- a/crates/core/src/dom/cmd.rs
+++ b/crates/core/src/dom/cmd.rs
@@ -7,7 +7,7 @@ use crate::dom::Effects;
 #[cfg(feature = "with-dom")]
 use wasm_bindgen::closure::Closure;
 
-/// Cnd is a way to tell the Runtime that something needs to be executed
+/// Cmd is a way to tell the Runtime that something needs to be executed
 pub struct Cmd<MSG>{
     /// commands
     pub(crate) commands: Vec<Command<MSG>>,


### PR DESCRIPTION
I happen to come across this.