### PR TITLE
Make VDOM functions public

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ with-node-macro = ["sauron-macro"]
 html-parser = ["sauron-html-parser"]
 use-skipdiff = ["sauron-core/use-skipdiff"]
 
-
 [dev-dependencies]
 console_error_panic_hook = "0.1.7"
 console_log = "1.0"
@@ -62,8 +61,13 @@ features = [
     "InputEvent",
     "console",
     "Performance",
+    "Element",
+    "Window",
 ]
 
+[dev-dependencies.criterion]
+version = "0.5.1"
+default-features = false
 
 [workspace]
 members = [
@@ -76,18 +80,6 @@ exclude = [
     "examples/custom-element",
     "examples/progressive-rendering",
 ]
-
-
-
-[patch.crates-io]
-#mt-dom = { git = "https://github.com/ivanceras/mt-dom.git", branch = "master" }
-#mt-dom = { path = "../mt-dom" }
-#jss = { git = "https://github.com/ivanceras/jss.git", branch = "master" }
-#jss = { path = "../jss" }
-
-[dev-dependencies.criterion]
-version = "0.5.1"
-default-features = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Sauron is inspired by elm-lang and is following The Elm Architecture.
 - html syntax for writing views
 - elegant macro to write styles
 - batteries included
+- standalone DOM/VirtualDOM patcher
+  (see [`examples/patch_dom_node`](https://github.com/ivanceras/sauron/tree/master/examples/patch_dom_node))
 
 ### Devoid of unnecessary framework complexities
 - **no** framework specific cli needed

--- a/crates/core/src/dom.rs
+++ b/crates/core/src/dom.rs
@@ -12,11 +12,32 @@ mod effects;
 use cfg_if::cfg_if;
 
 cfg_if! {if #[cfg(feature = "with-dom")] {
+    mod application;
+    mod dom_node;
+    mod dom_patch;
+    mod dom_attr;
+    mod http;
+    mod program;
+    mod raf;
+    mod ric;
+    mod window;
+    mod document;
+    mod time;
+    mod timeout;
+
+    pub mod events;
+    pub mod dispatch;
+    pub mod util;
+
     pub use application::{Application, Measurements, SkipDiff, skip_if, skip_diff, SkipPath};
     pub use component::{stateful_component, StatefulComponent, StatefulModel, StatelessModel};
     pub use component::component;
-    pub use dom_patch::{DomPatch, PatchVariant};
+    pub use dispatch::Dispatch;
+    pub use document::Document;
+    pub use dom_patch::{DomPatch, PatchVariant, apply_dom_patches, convert_patches};
     pub use dom_attr::{DomAttr, DomAttrValue, GroupedDomAttrValues};
+    pub use dom_node::DomNode;
+    pub use dom_node::create_dom_node;
     pub use http::Http;
     pub use program::{MountAction, MountTarget, Program, MountProcedure};
     pub use util::{
@@ -26,29 +47,10 @@ cfg_if! {if #[cfg(feature = "with-dom")] {
     pub use raf::{request_animation_frame, AnimationFrameHandle};
     pub use ric::{request_idle_callback, IdleCallbackHandle, IdleDeadline};
     pub use timeout::{delay, request_timeout_callback, TimeoutCallbackHandle};
-    pub use dispatch::Dispatch;
-    use crate::dom::events::MountEvent;
     pub use window::Window;
-    pub use dom_node::DomNode;
-    pub use document::Document;
     pub use time::Time;
 
-    mod application;
-    pub mod dispatch;
-    mod dom_node;
-    mod dom_patch;
-    mod dom_attr;
-    pub mod events;
-    mod http;
-    mod program;
-    pub mod util;
-    mod raf;
-    mod ric;
-    mod window;
-    mod document;
-    mod time;
-    mod timeout;
-
+    use crate::dom::events::MountEvent;
 
     /// Map the Event to DomEvent, which are browser events
     #[derive(Debug, Clone)]

--- a/crates/core/src/dom/dom_node.rs
+++ b/crates/core/src/dom/dom_node.rs
@@ -1,25 +1,22 @@
-use crate::dom::component::StatelessModel;
-use crate::dom::DomAttr;
-use crate::dom::GroupedDomAttrValues;
-use crate::dom::StatefulComponent;
-use crate::dom::StatefulModel;
-use crate::html::lookup;
-use crate::vdom::TreePath;
-use crate::{
-    dom::document,
-    dom::events::MountEvent,
-    dom::{Application, Program},
-    vdom,
-    vdom::{Attribute, Leaf},
+use std::{
+    borrow::Cow,
+    cell::{Ref, RefCell},
+    fmt,
+    rc::Rc,
 };
+
 use indexmap::IndexMap;
-use std::borrow::Cow;
-use std::cell::Ref;
-use std::cell::RefCell;
-use std::fmt;
-use std::rc::Rc;
 use wasm_bindgen::{closure::Closure, JsCast, JsValue};
 use web_sys::{self, Node};
+
+use crate::{
+    dom::{
+        component::StatelessModel, document, dom_patch, events::MountEvent, Application, DomAttr,
+        GroupedDomAttrValues, Program, StatefulComponent, StatefulModel,
+    },
+    html::lookup,
+    vdom::{self, Attribute, Leaf, TreePath},
+};
 
 pub(crate) type EventClosure = Closure<dyn FnMut(web_sys::Event)>;
 pub type NamedEventClosures = IndexMap<&'static str, EventClosure>;
@@ -33,6 +30,7 @@ pub type NamedEventClosures = IndexMap<&'static str, EventClosure>;
 pub struct DomNode {
     pub(crate) inner: DomInner,
 }
+
 #[derive(Clone)]
 pub enum DomInner {
     /// a reference to an element node
@@ -648,149 +646,133 @@ where
 {
     /// Create a dom node
     pub fn create_dom_node(&self, node: &vdom::Node<APP::MSG>) -> DomNode {
-        match node {
-            vdom::Node::Element(elm) => self.create_element_node(elm),
-            vdom::Node::Leaf(leaf) => self.create_leaf_node(leaf),
-        }
+        let ev_callback = self.create_ev_callback();
+        create_dom_node(node, ev_callback)
     }
 
-    fn create_element_node(&self, elm: &vdom::Element<APP::MSG>) -> DomNode {
-        let document = document();
-        let element = if let Some(namespace) = elm.namespace() {
-            document
-                .create_element_ns(Some(intern(namespace)), intern(elm.tag()))
-                .expect("Unable to create element")
-        } else {
-            document
-                .create_element(intern(elm.tag()))
-                .expect("create element")
+    pub(crate) fn create_ev_callback(&self) -> impl Fn(APP::MSG) + Clone {
+        let program = self.downgrade();
+        let ev_callback = move |msg| {
+            let mut program = program.upgrade().expect("must upgrade");
+            program.dispatch(msg);
         };
-        // TODO: dispatch the mount event recursively after the dom node is mounted into
-        // the root node
-        let attrs = Attribute::merge_attributes_of_same_name(elm.attributes().iter());
-
-        let dom_node = DomNode {
-            inner: DomInner::Element {
-                element,
-                listeners: Rc::new(RefCell::new(None)),
-                children: Rc::new(RefCell::new(vec![])),
-                has_mount_callback: elm.has_mount_callback(),
-            },
-        };
-        let dom_attrs = attrs.iter().map(|a| self.convert_attr(a));
-        dom_node.set_dom_attrs(dom_attrs).expect("set dom attrs");
-        let children: Vec<DomNode> = elm
-            .children()
-            .iter()
-            .map(|child| self.create_dom_node(child))
-            .collect();
-        dom_node.append_children(children);
-        dom_node
-    }
-
-    fn create_leaf_node(&self, leaf: &vdom::Leaf<APP::MSG>) -> DomNode {
-        match leaf {
-            Leaf::Text(txt) => DomNode {
-                inner: DomInner::Text(document().create_text_node(txt)),
-            },
-            Leaf::Symbol(symbol) => DomNode {
-                inner: DomInner::Symbol(symbol.clone()),
-            },
-            Leaf::Comment(comment) => DomNode {
-                inner: DomInner::Comment(document().create_comment(comment)),
-            },
-            Leaf::Fragment(nodes) => self.create_fragment_node(nodes),
-            // NodeList that goes here is only possible when it is the root_node,
-            // since node_list as children will be unrolled into as child_elements of the parent
-            // We need to wrap this node_list into doc_fragment since root_node is only 1 element
-            Leaf::NodeList(nodes) => self.create_fragment_node(nodes),
-            Leaf::StatefulComponent(comp) => {
-                //TODO: also put the children and attributes here
-                DomNode {
-                    inner: DomInner::StatefulComponent {
-                        comp: Rc::clone(&comp.comp),
-                        dom_node: Rc::new(self.create_stateful_component(comp)),
-                    },
-                }
-            }
-            Leaf::StatelessComponent(comp) => self.create_stateless_component(comp),
-            Leaf::TemplatedView(view) => {
-                unreachable!("template view should not be created: {:#?}", view)
-            }
-            Leaf::DocType(_) => unreachable!("doc type is never converted"),
-        }
-    }
-
-    fn create_fragment_node<'a>(
-        &self,
-        nodes: impl IntoIterator<Item = &'a vdom::Node<APP::MSG>>,
-    ) -> DomNode {
-        let fragment = document().create_document_fragment();
-        let dom_node = DomNode {
-            inner: DomInner::Fragment {
-                fragment,
-                children: Rc::new(RefCell::new(vec![])),
-            },
-        };
-        let children = nodes
-            .into_iter()
-            .map(|node| self.create_dom_node(node))
-            .collect();
-        dom_node.append_children(children);
-        dom_node
+        ev_callback
     }
 }
 
-/// A node along with all of the closures that were created for that
-/// node's events and all of it's child node's events.
-impl<APP> Program<APP>
+/// Create a dom node
+pub fn create_dom_node<Msg, F>(node: &vdom::Node<Msg>, ev_callback: F) -> DomNode
 where
-    APP: Application,
+    Msg: 'static,
+    F: Fn(Msg) + 'static + Clone,
 {
-    /// TODO: register the template if not yet
-    /// pass a program to leaf component and mount itself and its view to the program
-    /// There are 2 types of children components of Stateful Component
-    /// - Internal children
-    /// - External children
-    /// Internal children is managed by the Stateful Component
-    /// while external children are managed by the top level program.
-    /// The external children can be diffed, and send the patches to the StatefulComponent
-    ///   - The TreePath of the children starts at the external children location
-    /// The attributes affects the Stateful component state.
-    /// The attributes can be diff and send the patches to the StatefulComponent
-    ///  - Changes to the attributes will call on attribute_changed of the StatefulComponent
-    fn create_stateful_component(&self, comp: &StatefulModel<APP::MSG>) -> DomNode {
-        let comp_node = self.create_dom_node(&crate::html::div(
-            [crate::html::attributes::class("component")]
-                .into_iter()
-                .chain(comp.attrs.clone()),
-            [],
-        ));
+    match node {
+        vdom::Node::Element(elm) => create_element_node(elm, ev_callback),
+        vdom::Node::Leaf(leaf) => create_leaf_node(leaf, ev_callback),
+    }
+}
 
-        let dom_attrs: Vec<DomAttr> = comp.attrs.iter().map(|a| self.convert_attr(a)).collect();
-        for dom_attr in dom_attrs.into_iter() {
-            log::info!("calling attribute changed..");
-            comp.comp.borrow_mut().attribute_changed(dom_attr);
+fn create_element_node<Msg, F>(elm: &vdom::Element<Msg>, ev_callback: F) -> DomNode
+where
+    Msg: 'static,
+    F: Fn(Msg) + 'static + Clone,
+{
+    let document = document();
+    let element = if let Some(namespace) = elm.namespace() {
+        document
+            .create_element_ns(Some(intern(namespace)), intern(elm.tag()))
+            .expect("Unable to create element")
+    } else {
+        document
+            .create_element(intern(elm.tag()))
+            .expect("create element")
+    };
+    // TODO: dispatch the mount event recursively after the dom node is mounted into
+    // the root node
+    let attrs = Attribute::merge_attributes_of_same_name(elm.attributes().iter());
+
+    let dom_node = DomNode {
+        inner: DomInner::Element {
+            element,
+            listeners: Rc::new(RefCell::new(None)),
+            children: Rc::new(RefCell::new(vec![])),
+            has_mount_callback: elm.has_mount_callback(),
+        },
+    };
+    let dom_attrs = attrs
+        .iter()
+        .map(|a| dom_patch::convert_attr(a, ev_callback.clone()));
+    dom_node.set_dom_attrs(dom_attrs).expect("set dom attrs");
+    let children: Vec<DomNode> = elm
+        .children()
+        .iter()
+        .map(|child| create_dom_node(child, ev_callback.clone()))
+        .collect();
+    dom_node.append_children(children);
+    dom_node
+}
+
+fn create_leaf_node<Msg, F>(leaf: &vdom::Leaf<Msg>, ev_callback: F) -> DomNode
+where
+    Msg: 'static,
+    F: Fn(Msg) + 'static + Clone,
+{
+    match leaf {
+        Leaf::Text(txt) => DomNode {
+            inner: DomInner::Text(document().create_text_node(txt)),
+        },
+        Leaf::Symbol(symbol) => DomNode {
+            inner: DomInner::Symbol(symbol.clone()),
+        },
+        Leaf::Comment(comment) => DomNode {
+            inner: DomInner::Comment(document().create_comment(comment)),
+        },
+        Leaf::Fragment(nodes) => create_fragment_node(nodes, ev_callback),
+
+        // NodeList that goes here is only possible when it is the root_node,
+        // since node_list as children will be unrolled into as child_elements of the parent
+        // We need to wrap this node_list into doc_fragment since root_node is only 1 element
+        Leaf::NodeList(nodes) => create_fragment_node(nodes, ev_callback),
+
+        Leaf::StatefulComponent(comp) => {
+            //TODO: also put the children and attributes here
+            DomNode {
+                inner: DomInner::StatefulComponent {
+                    comp: Rc::clone(&comp.comp),
+                    dom_node: Rc::new(create_stateful_component(comp, ev_callback)),
+                },
+            }
         }
+        Leaf::StatelessComponent(comp) => create_stateless_component(comp, ev_callback),
 
-        // the component children is manually appended to the StatefulComponent
-        // here to allow the conversion of dom nodes with its event
-        // listener and removing the generics msg
-        let created_children = comp
-            .children
-            .iter()
-            .map(|child| self.create_dom_node(child))
-            .collect();
-        comp.comp.borrow_mut().append_children(created_children);
-        comp_node
+        Leaf::TemplatedView(view) => {
+            unreachable!("template view should not be created: {:#?}", view)
+        }
+        Leaf::DocType(_) => unreachable!("doc type is never converted"),
     }
+}
 
-    #[allow(unused)]
-    pub(crate) fn create_stateless_component(&self, comp: &StatelessModel<APP::MSG>) -> DomNode {
-        let comp_view = &comp.view;
-        let real_comp_view = comp_view.unwrap_template_ref();
-        self.create_dom_node(real_comp_view)
-    }
+fn create_fragment_node<'a, Msg, F>(
+    nodes: impl IntoIterator<Item = &'a vdom::Node<Msg>>,
+    ev_callback: F,
+) -> DomNode
+where
+    Msg: 'static,
+    F: Fn(Msg) + 'static + Clone,
+{
+    let fragment = document().create_document_fragment();
+    let dom_node = DomNode {
+        inner: DomInner::Fragment {
+            fragment,
+            children: Rc::new(RefCell::new(vec![])),
+        },
+    };
+    let children = nodes
+        .into_iter()
+        .map(|node| create_dom_node(node, ev_callback.clone()))
+        .collect();
+    dom_node.append_children(children);
+    dom_node
 }
 
 /// render the underlying real dom node into string
@@ -844,4 +826,68 @@ pub fn render_real_dom(node: &web_sys::Node, buffer: &mut dyn fmt::Write) -> fmt
         }
         _ => todo!("for other else"),
     }
+}
+
+#[allow(unused)]
+pub(crate) fn create_stateless_component<Msg, F>(
+    comp: &StatelessModel<Msg>,
+    ev_callback: F,
+) -> DomNode
+where
+    Msg: 'static,
+    F: Fn(Msg) + 'static + Clone,
+{
+    let comp_view = &comp.view;
+    let real_comp_view = comp_view.unwrap_template_ref();
+    create_dom_node(real_comp_view, ev_callback)
+}
+
+/// TODO: register the template if not yet
+/// pass a program to leaf component and mount itself and its view to the program
+/// There are 2 types of children components of Stateful Component
+/// - Internal children
+/// - External children
+/// Internal children is managed by the Stateful Component
+/// while external children are managed by the top level program.
+/// The external children can be diffed, and send the patches to the StatefulComponent
+///   - The TreePath of the children starts at the external children location
+/// The attributes affects the Stateful component state.
+/// The attributes can be diff and send the patches to the StatefulComponent
+///  - Changes to the attributes will call on attribute_changed of the StatefulComponent
+fn create_stateful_component<Msg, F>(comp: &StatefulModel<Msg>, ev_callback: F) -> DomNode
+where
+    Msg: 'static,
+    F: Fn(Msg) + 'static + Clone,
+{
+    let comp_node = create_dom_node(
+        &crate::html::div(
+            [crate::html::attributes::class("component")]
+                .into_iter()
+                .chain(comp.attrs.clone()),
+            [],
+        ),
+        ev_callback.clone(),
+    );
+
+    let dom_attrs: Vec<DomAttr> = comp
+        .attrs
+        .iter()
+        .map(|a| dom_patch::convert_attr(a, ev_callback.clone()))
+        .collect();
+
+    for dom_attr in dom_attrs.into_iter() {
+        log::info!("calling attribute changed..");
+        comp.comp.borrow_mut().attribute_changed(dom_attr);
+    }
+
+    // the component children is manually appended to the StatefulComponent
+    // here to allow the conversion of dom nodes with its event
+    // listener and removing the generics msg
+    let created_children = comp
+        .children
+        .iter()
+        .map(|child| create_dom_node(child, ev_callback.clone()))
+        .collect();
+    comp.comp.borrow_mut().append_children(created_children);
+    comp_node
 }

--- a/crates/core/src/dom/dom_node.rs
+++ b/crates/core/src/dom/dom_node.rs
@@ -713,9 +713,7 @@ where
                     },
                 }
             }
-            Leaf::StatelessComponent(comp) => {
-                    self.create_stateless_component(comp)
-            }
+            Leaf::StatelessComponent(comp) => self.create_stateless_component(comp),
             Leaf::TemplatedView(view) => {
                 unreachable!("template view should not be created: {:#?}", view)
             }

--- a/crates/core/src/dom/program.rs
+++ b/crates/core/src/dom/program.rs
@@ -737,6 +737,18 @@ where
     pub fn dispatch(&mut self, msg: APP::MSG) {
         self.dispatch_multiple([msg])
     }
+
+    /// patch the DOM to reflect the App's view
+    ///
+    /// Note: This is in another function so as to allow tests to use this shared code
+    pub fn create_dom_patch(&self, new_vdom: &vdom::Node<APP::MSG>) -> Vec<DomPatch> {
+        create_dom_patch(
+            &self.root_node,
+            &self.app_context.current_vdom(),
+            new_vdom,
+            self.create_ev_callback(),
+        )
+    }
 }
 
 fn create_dom_patch<Msg, F>(
@@ -777,11 +789,7 @@ where
         &mut self,
         new_vdom: vdom::Node<APP::MSG>,
     ) -> Result<usize, JsValue> {
-        let dom_patches = {
-            let current_vdom = self.app_context.current_vdom();
-            let ev_callback = self.create_ev_callback();
-            create_dom_patch(&self.root_node, &current_vdom, &new_vdom, ev_callback)
-        };
+        let dom_patches = self.create_dom_patch(&new_vdom);
         let total_patches = dom_patches.len();
         self.pending_patches.borrow_mut().extend(dom_patches);
 

--- a/crates/core/src/dom/program.rs
+++ b/crates/core/src/dom/program.rs
@@ -29,8 +29,6 @@ use web_sys;
 pub(crate) use app_context::AppContext;
 pub use mount_procedure::{MountAction, MountProcedure, MountTarget};
 
-
-
 thread_local! {
     static CANCEL_CNT: RefCell<i32> = RefCell::new(0);
 }
@@ -451,17 +449,24 @@ where
                 let mut program = self.clone();
                 //#[cfg(feature = "with-debounce")]
                 crate::dom::request_timeout_callback(
-                    move||{
+                    move || {
                         program.update_dom().unwrap();
-                    }, remaining.round() as i32).unwrap();
+                    },
+                    remaining.round() as i32,
+                )
+                .unwrap();
                 log::info!("update is cancelled..");
-                CANCEL_CNT.with_borrow_mut(|c|*c += 1);
-                return Ok(())
+                CANCEL_CNT.with_borrow_mut(|c| *c += 1);
+                return Ok(());
             }
         }
         log::info!("Doing and update...");
-        UPDATE_CNT.with_borrow_mut(|c|*c += 1);
-        log::info!("ratio(cancelled/update): {}/{}", CANCEL_CNT.with_borrow(|c|*c), UPDATE_CNT.with_borrow(|c|*c));
+        UPDATE_CNT.with_borrow_mut(|c| *c += 1);
+        log::info!(
+            "ratio(cancelled/update): {}/{}",
+            CANCEL_CNT.with_borrow(|c| *c),
+            UPDATE_CNT.with_borrow(|c| *c)
+        );
         // a new view is created due to the app update
         let view = self.app_context.view();
         let t2 = now();
@@ -518,7 +523,6 @@ where
                 log::warn!("dispatch took {}ms", measurements.total_time.round());
             }
         }
-
 
         // tell the app about the performance measurement and only if there was patches applied
         #[cfg(feature = "with-measure")]

--- a/crates/html-parser/src/lib.rs
+++ b/crates/html-parser/src/lib.rs
@@ -1,17 +1,17 @@
 #![deny(warnings)]
-use rphtml::config::ParseOptions;
-use rphtml::parser::Doc;
-use rphtml::parser::NodeType;
-use rphtml::types::BoxDynError;
+
+use std::{fmt, io, ops::Deref};
+
+use rphtml::{
+    config::ParseOptions,
+    parser::{Doc, NodeType},
+    types::BoxDynError,
+};
+
 use sauron_core::{
     html::{attributes::*, lookup, *},
-    vdom::AttributeValue,
-    vdom::Node,
-    vdom::Value,
+    vdom::{AttributeValue, Node, Value},
 };
-use std::fmt;
-use std::io;
-use std::ops::Deref;
 
 /// all the possible error when parsing html string
 #[derive(Debug, thiserror::Error)]
@@ -30,7 +30,8 @@ pub enum ParseError {
     InvalidTag(String),
 }
 
-/// parse the html string and build a node tree
+/// Parse escaped html strings like `"Hello&#x20;world&#x21;"`
+/// into `"Hello world!"` and then into a node tree.
 pub fn raw_html<MSG>(html: &str) -> Node<MSG> {
     // decode html entitiesd back since it will be safely converted into text
     let html = html_escape::decode_html_entities(html);
@@ -39,7 +40,8 @@ pub fn raw_html<MSG>(html: &str) -> Node<MSG> {
         .expect("must have a node")
 }
 
-/// the document is not wrapped with html
+/// Parse none-escaped html strings like `"Hello world!"`
+/// into a node tree (see also [raw_html]).
 pub fn parse_html<MSG>(html: &str) -> Result<Option<Node<MSG>>, ParseError> {
     let doc = Doc::parse(
         html,

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -209,7 +209,6 @@ pub fn extract_skip_diff(input: proc_macro::TokenStream) -> proc_macro::TokenStr
     extract_skip_diff::to_token_stream(input).into()
 }
 
-
 /// build a css string
 ///
 /// # Example:

--- a/examples/patch_dom_node/Cargo.toml
+++ b/examples/patch_dom_node/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "patch_dom_node"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+console_error_panic_hook = "0.1.7"
+console_log = { version = "1.0.0", features = ["color"] }
+log = "0.4.25"
+sauron-core = { version = "0.61.9", path = "../../crates/core" }
+sauron-html-parser = { version = "0.61.9", path = "../../crates/html-parser" }
+web-sys = "0.3.77"

--- a/examples/patch_dom_node/index.html
+++ b/examples/patch_dom_node/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <link data-trunk rel="rust" data-wasm-opt="z" />
+    <title>Sauron • Use VDOM</title>
+  </head>
+  <body></body>
+</html>

--- a/examples/patch_dom_node/src/main.rs
+++ b/examples/patch_dom_node/src/main.rs
@@ -1,0 +1,50 @@
+use std::{cell::RefCell, rc::Rc};
+
+use sauron_core::{
+    dom::{self, DomNode},
+    prelude::Node,
+    vdom,
+};
+use sauron_html_parser::parse_html;
+
+fn main() {
+    _ = console_log::init_with_level(log::Level::Debug);
+    console_error_panic_hook::set_once();
+    log::info!("Run VDOM patch example");
+
+    let ev_callback = |_| {};
+
+    let body_node = DomNode::from(web_sys::Node::from(dom::util::body()));
+    let mount_node = Rc::new(RefCell::new(Some(body_node)));
+
+    let new_html = r#"
+      <article class="some-class">
+        <div id = "my-hello-world-id">
+            Hello world!
+            If you can see this text on the webpage then the DOM patching was executed!
+        </div>
+        <footer>This is a footer</footer>
+      </article>"#;
+
+    let old_node: Node<()> = parse_html::<()>("").unwrap().unwrap();
+    let new_node: Node<()> = parse_html::<()>(new_html).unwrap().unwrap();
+
+    let root = dom::create_dom_node(&old_node, ev_callback);
+    let root_node = Rc::new(RefCell::new(Some(root)));
+
+    let vdom_patches = vdom::diff(&old_node, &new_node);
+    log::info!("Created {} VDOM patch(es)", vdom_patches.len());
+    log::debug!("VDOM patch(es): {vdom_patches:?}");
+
+    // convert vdom patch to real dom patches
+    let dom_patches = dom::convert_patches(
+        &root_node.borrow().as_ref().unwrap(),
+        &vdom_patches,
+        ev_callback,
+    )
+    .unwrap();
+    log::info!("Converted {} DOM patch(es)", dom_patches.len());
+    log::debug!("DOM patch(es): {dom_patches:?}");
+
+    dom::apply_dom_patches(root_node, mount_node, dom_patches).unwrap();
+}

--- a/tests/dom_vdom_standalone.rs
+++ b/tests/dom_vdom_standalone.rs
@@ -1,0 +1,67 @@
+use std::{cell::RefCell, rc::Rc};
+
+use wasm_bindgen_test::*;
+use web_sys::{Element, HtmlElement};
+
+use sauron_core::{
+    dom::{self, DomNode},
+    prelude::Node,
+    vdom,
+};
+use sauron_html_parser::{parse_html, raw_html};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+// Verify that our DomUpdater's patch method works.
+// We test a simple case here, since diff_patch.rs is responsible for testing more complex
+// diffing and patching.
+#[wasm_bindgen_test]
+fn test_dom_vdom_standalone() {
+    console_log::init_with_level(log::Level::Trace).unwrap();
+    console_error_panic_hook::set_once();
+
+    let ev_callback = |_| {};
+
+    let window = web_sys::window().expect("no global `window` exists");
+    let document = window.document().expect("should have a document on window");
+
+    let div: Element = document.create_element("div").unwrap();
+    div.set_attribute("id", "here").unwrap();
+    document.body().unwrap().append_child(&div).unwrap();
+
+    let web_sys_node: web_sys::Node = web_sys::Node::from(div);
+    let div_node = DomNode::from(web_sys_node);
+    let mount_node = Rc::new(RefCell::new(Some(div_node)));
+
+    let new_html = r#"
+    <div>boak</div>
+    "#;
+
+    let old_node: Node<()> = parse_html::<()>("").unwrap().unwrap();
+    let new_node: Node<()> = raw_html::<()>(new_html);
+    let root = dom::create_dom_node(&old_node, ev_callback);
+    let root_node = Rc::new(RefCell::new(Some(root)));
+
+    let vdom_patches = vdom::diff(&old_node, &new_node);
+    log::debug!("Created {} VDOM patch(es)", vdom_patches.len());
+    log::debug!("Created {:?}", vdom_patches);
+
+    // convert vdom patch to real dom patches
+    let dom_patches = dom::convert_patches(
+        &root_node.borrow().as_ref().unwrap(),
+        &vdom_patches,
+        ev_callback,
+    )
+    .unwrap();
+    log::debug!("Converted {} DOM patch(es)", dom_patches.len());
+    log::debug!("Converted {:?}", dom_patches);
+
+    dom::apply_dom_patches(root_node, mount_node, dom_patches).unwrap();
+
+    let target: Element = document.get_element_by_id("here").unwrap();
+
+    // Get the inner HTML from the body element
+    let html_content: String = target.inner_html();
+
+    assert_eq!("<div>boak</div>".to_string(), html_content);
+}


### PR DESCRIPTION
Motivation:
To be able to manually use the virtual DOM, we need to have access to functions like  `create_dom_node`, `apply_dom_patches` etc.

Solution:
Decouple the functions from the `Program`